### PR TITLE
Update Czech translation in cs.json

### DIFF
--- a/assets/translations/cs.json
+++ b/assets/translations/cs.json
@@ -37,8 +37,8 @@
 
   "today_label": "dneska",
   "tomorrow_label": "zítra",
-  "ends_in_multiple_days_label": "dní",
-  "ends_in_days_label": "dny",
+  "ends_in_multiple_days_label": "dny",
+  "ends_in_days_label": "dní",
   "ends_in_label": "Končí za",
   "sale_ends_in_label": "Sleva končí",
   "sale_ends_in_not_picked_label": "Vybrat",


### PR DESCRIPTION
Corrects the usage of "dní" and "dny". These two terms were misplaced and have now been switched to their proper positions.